### PR TITLE
better quoting in ckeditor/wblink

### DIFF
--- a/ckeditor/plugins/wblink/pages.php
+++ b/ckeditor/plugins/wblink/pages.php
@@ -86,7 +86,7 @@ $ModuleList = "var ModuleList = new Array();";
 
 $newsImgSections = $database->query("SELECT * FROM ".TABLE_PREFIX."sections WHERE module = 'news_img'");
 while ($section = $newsImgSections->fetchRow()) {
-    $newsImg = $database->query("SELECT title, link, post_id FROM ".TABLE_PREFIX."mod_news_img_posts WHERE active=1 AND section_id = ".$section['section_id']);
+    $newsImg = $database->query("SELECT `title`, `link`, `post_id` FROM ".TABLE_PREFIX."mod_news_img_posts WHERE active=1 AND section_id=".$section['section_id']);
     $ModuleList .= "ModuleList[".$section['page_id']."] = 'NewsWithImages';";
     $NewsItemsSelectBox .= "NewsItemsSelectBox[".$section['page_id']."] = new Array();";
     while ($newsImg && $item = $newsImg->fetchRow()) {
@@ -97,7 +97,7 @@ while ($section = $newsImgSections->fetchRow()) {
 
 $newsSections = $database->query("SELECT * FROM ".TABLE_PREFIX."sections WHERE module = 'news'");
 while ($section = $newsSections->fetchRow()) {
-    $news = $database->query("SELECT title, link, page_id, post_id FROM ".TABLE_PREFIX."mod_news_posts WHERE active=1 AND section_id = ".$section['section_id']);
+    $news = $database->query("SELECT `title`, `link`, `page_id`, `post_id` FROM ".TABLE_PREFIX."mod_news_posts WHERE active=1 AND section_id=".$section['section_id']);
     $ModuleList .= "ModuleList[".$section['page_id']."] = 'News';";
     $NewsItemsSelectBox .= "NewsItemsSelectBox[".$section['page_id']."] = new Array();";
     while ($news && $item = $news->fetchRow()) {
@@ -108,7 +108,7 @@ while ($section = $newsSections->fetchRow()) {
 
 $topicsSections = $database->query("SELECT * FROM ".TABLE_PREFIX."sections WHERE module = 'topics'");
 while ($section = $topicsSections->fetchRow()) {
-    $topics = $database->query("SELECT title, link, page_id, topic_id FROM ".TABLE_PREFIX."mod_topics WHERE active > 0 AND section_id = ".$section['section_id']);
+    $topics = $database->query("SELECT `title`, `link`, `page_id`, `topic_id` FROM ".TABLE_PREFIX."mod_topics WHERE active>0 AND section_id=".$section['section_id']);
     $ModuleList .= "ModuleList[".$section['page_id']."] = 'Topics';";
     $NewsItemsSelectBox .= "NewsItemsSelectBox[".$section['page_id']."] = new Array();";
     while ($topics && $item = $topics->fetchRow()) {
@@ -119,7 +119,7 @@ while ($section = $topicsSections->fetchRow()) {
 
 $bakerySections = $database->query("SELECT * FROM ".TABLE_PREFIX."sections WHERE module = 'bakery'");
 while ($section = $bakerySections->fetchRow()) {
-    $bakery = $database->query("SELECT title, link, page_id, item_id FROM ".TABLE_PREFIX."mod_bakery_items WHERE active=1 AND section_id = ".$section['section_id']);
+    $bakery = $database->query("SELECT `title`, `link`, `page_id`, `item_id` FROM ".TABLE_PREFIX."mod_bakery_items WHERE active=1 AND section_id=".$section['section_id']);
     $ModuleList .= "ModuleList[".$section['page_id']."] = 'Bakery';";
     $NewsItemsSelectBox .= "NewsItemsSelectBox[".$section['page_id']."] = new Array();";
     while ($bakery && $item = $bakery->fetchRow()) {


### PR DESCRIPTION
Hi,

ich habe bemerkt, dass die NWI Abfrage bei mir das wblink plugin gelegentlich lahm gelegt hat. Es stellte sich heraus, dass im jQuery Output php-Fehlermeldungen rein gemischt waren, die darauf hin gedeutet haben, dass manche sql Statements (in meinem Fall war's die Abfrage der NWI posts) NULL zurückgeliefert haben, worauf man logischerweise kein fetchRow() anwenden kann.

Commit https://github.com/WBCE/WBCE_CMS/commit/e15d482b16549233f2456e3a565fa32a8e264f43 hat zunächst lediglich das Symptom behoben (danke fürs Übernehmen in die neue Version) - und gestern bin ich der Sache noch ein Stückchen weiter auf den Grund gegangen: Dass hier NULL zurückgeliefert wurde, lag wohl an einem unsauberen Quoting im SQL Statement. Ich hab dafür gestern noch https://github.com/WBCE/WBCE_CMS/commit/6ff9fcfd8717324fb4e5dcaa48e71836d54ccfd2  auf dem WBCE master committed, womit dann auch wieder die einzelnen Posts zugreifbar sind. Das zieht sich durch alle News-artigen Module hindurch. Florian hat's schon getestet. 

Dieser Pull Request übernimmt die Änderung quasi in dein CKEditor-Repo.